### PR TITLE
Added Support for JPEG Format Export

### DIFF
--- a/Sources/imgfile/AvailableExtensions.swift
+++ b/Sources/imgfile/AvailableExtensions.swift
@@ -7,23 +7,40 @@
 
 import Foundation
 import Cocoa
+import ImageIO
+import UniformTypeIdentifiers
 
 enum AvailableExtensions {
     case png
 //    jpg/gif is not supported
-//    case jpg
+    case jpg
 //    case gif
 }
 
 typealias ImgType = NSPasteboard.PasteboardType
 
+@available(macOS 14, *)
 extension AvailableExtensions {
     static private var valueMap: [String: AvailableExtensions] = [
         "png": .png,
-//        "jpeg": .jpg,
-//        "jpg": .jpg,
+        "jpeg": .jpg,
+        "jpg": .jpg,
 //        "gif": .gif,
     ]
+    init(withDefaults string: String?) {
+        guard let ext = string else {
+            self = .png
+            return
+        }
+        for (name, value) in AvailableExtensions.valueMap {
+            if name.caseInsensitiveCompare(ext) == .orderedSame {
+                self = value
+                return
+            }
+        }
+        self = .png
+    }
+
     init?(from string: String) {
         for (name, value) in AvailableExtensions.valueMap {
             if name.caseInsensitiveCompare(string) == .orderedSame {
@@ -38,9 +55,44 @@ extension AvailableExtensions {
         get {
             return switch self {
             case .png: NSPasteboard.PasteboardType.png;
-//            case .jpg: NSPasteboard.PasteboardType("jpeg");
+            case .jpg: NSPasteboard.PasteboardType("jpeg");
 //            case .gif: NSPasteboard.PasteboardType("gif");
             }
         }
+    }
+
+    func convertFormat(_ data: Data) -> Data? {
+        if self == .png {
+            return data
+        }
+        guard
+            let cgDataProvider = CGDataProvider(data: data as CFData),
+            let cgImage = CGImage(
+                    pngDataProviderSource: cgDataProvider,
+                    decode: nil,
+                    shouldInterpolate: false,
+                    intent: .defaultIntent
+            ),
+            let cfMutableData = CFDataCreateMutable(kCFAllocatorDefault, 0),
+            let cgImageDestination = CGImageDestinationCreateWithData(
+                    cfMutableData,
+                    UTType.jpeg.identifier as CFString,
+                    1,
+                    nil
+            )
+        else {
+          return nil
+        }
+        CGImageDestinationAddImage(
+                cgImageDestination,
+                cgImage,
+                [
+                        kCGImageDestinationLossyCompressionQuality: 1.0 as CGFloat
+                ] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(cgImageDestination) else {
+            return nil
+        }
+        return cfMutableData as Data
     }
 }

--- a/Sources/imgfile/Clipboard.swift
+++ b/Sources/imgfile/Clipboard.swift
@@ -13,8 +13,8 @@ enum Clipboard {
 }
 
 extension Clipboard {
-    func data(_ ext: AvailableExtensions) -> Data? {
+    func data(forType type: ImgType) -> Data? {
         let clipboard = NSPasteboard.general
-        return clipboard.data(forType: ext.imgType)
+        return clipboard.data(forType: type)
     }
 }

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -23,7 +23,7 @@ extension ImgFile {
         }
 
         let clipboard = Clipboard.general
-        guard let imageData = clipboard.data(AvailableExtensions.png) else {
+        guard let imageData = clipboard.data(forType: NSPasteboard.PasteboardType.png) else {
             throw RuntimeError(description: "failed to read a clipboard image as png")
         }
 

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Cocoa
 
+@available(macOS 14, *)
 extension ImgFile {
 
     static func execute(with imgFile: ImgFile) throws {
@@ -22,12 +23,19 @@ extension ImgFile {
             throw InvalidOptionsError("invalid file URL \(filePath)")
         }
 
+        let extItems = filePath.split(separator: ".")
+        let outputFormat = AvailableExtensions(withDefaults: extItems.last?.lowercased())
+
         let clipboard = Clipboard.general
         guard let imageData = clipboard.data(forType: NSPasteboard.PasteboardType.png) else {
             throw RuntimeError(description: "failed to read a clipboard image as png")
         }
 
-        try imageData.write(to: fileURL, options: NSData.WritingOptions.atomic)
+        guard let outputData = outputFormat.convertFormat(imageData) else {
+            throw RuntimeError(description: "failed to convert format of image to \(outputFormat)")
+        }
+
+        try outputData.write(to: fileURL, options: NSData.WritingOptions.atomic)
     }
 }
 

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -9,6 +9,11 @@ import Foundation
 import Cocoa
 
 extension ImgFile {
+
+    static func execute(with imgFile: ImgFile) throws {
+        try execute(imgFile.filePath)
+    }
+
     static func execute(_ filePath: String) throws {
         guard let fileURL = URL(withUnknownFormatOf: filePath) else {
             if filePath.hasPrefix("https://") || filePath.hasPrefix("http://") {

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -10,11 +10,10 @@ import Cocoa
 
 extension ImgFile {
     static func execute(_ filePath: String) throws {
-        if filePath.hasPrefix("https://") || filePath.hasPrefix("http://") {
-            throw InvalidOptionsError("http/https protocol not supported")
-        }
-
         guard let fileURL = URL(withUnknownFormatOf: filePath) else {
+            if filePath.hasPrefix("https://") || filePath.hasPrefix("http://") {
+                throw InvalidOptionsError("http/https protocol not supported")
+            }
             throw InvalidOptionsError("invalid file URL \(filePath)")
         }
 
@@ -43,7 +42,9 @@ struct RuntimeError: Error, CustomStringConvertible {
 
 extension URL {
     init?(withUnknownFormatOf filePath: String) {
-        if filePath.hasPrefix("file://") {
+        if filePath.hasPrefix("https://") || filePath.hasPrefix("http://") {
+            return nil
+        } else if filePath.hasPrefix("file://") {
             guard let tempURL = URL(string: filePath) else {
                 return nil
             }

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -14,16 +14,8 @@ extension ImgFile {
             throw InvalidOptionsError("http/https protocol not supported")
         }
 
-        let fileURL: URL
-        if filePath.hasPrefix("file://") {
-            guard let tempURL = URL(string: filePath) else {
-                throw InvalidOptionsError("invalid file URL \(filePath)")
-            }
-            fileURL = tempURL
-        } else if filePath.hasPrefix("/") {
-            fileURL = URL(fileURLWithPath: filePath)
-        } else {
-            fileURL = URL(fileURLWithPath: FileManager().currentDirectoryPath).appendingPathComponent(filePath)
+        guard let fileURL = URL(withUnknownFormatOf: filePath) else {
+            throw InvalidOptionsError("invalid file URL \(filePath)")
         }
 
         let clipboard = Clipboard.general
@@ -47,4 +39,19 @@ extension InvalidOptionsError {
 
 struct RuntimeError: Error, CustomStringConvertible {
     var description: String
+}
+
+extension URL {
+    init?(withUnknownFormatOf filePath: String) {
+        if filePath.hasPrefix("file://") {
+            guard let tempURL = URL(string: filePath) else {
+                return nil
+            }
+            self = tempURL
+        } else if filePath.hasPrefix("/") {
+            self = URL(fileURLWithPath: filePath)
+        } else {
+            self = URL(fileURLWithPath: FileManager().currentDirectoryPath).appendingPathComponent(filePath)
+        }
+    }
 }

--- a/Sources/imgfile/imgfile.swift
+++ b/Sources/imgfile/imgfile.swift
@@ -3,8 +3,6 @@ import ArgumentParser
 @main
 struct ImgFile: ParsableCommand {
 
-    static let binaryName: String = "imgwrite";
-
     @Argument(help: "The file path")
     var filePath: String
 

--- a/Sources/imgfile/imgfile.swift
+++ b/Sources/imgfile/imgfile.swift
@@ -8,7 +8,7 @@ struct ImgFile: ParsableCommand {
 
     mutating func run() throws {
         do {
-            try ImgFile.execute(filePath)
+            try ImgFile.execute(with: self)
         } catch let err as InvalidOptionsError {
             throw ValidationError(err.description)
         }

--- a/Sources/imgfile/imgfile.swift
+++ b/Sources/imgfile/imgfile.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 
 @main
+@available(macOS 14, *)
 struct ImgFile: ParsableCommand {
 
     @Argument(help: "The file path")


### PR DESCRIPTION
We have now added the ability to write files in the JPEG format.
This feature determines the file extension from the file name provided as an argument to the command.

- If the extension is .jpeg or .jpg, the data is converted to JPEG format and saved.
- If an extension cannot be obtained from the file name, it will default to saving in the PNG format, as was the case previously.