### PR TITLE
Fix resources not found

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,19 +24,19 @@ let package = Package(
                     dependencies: [
                         .product(name: "ArgumentParser", package: "swift-argument-parser"),
                     ],
-                    resources: [.copy("version.txt")]
+                    resources: [.embedInCode("version.txt")]
                     ),
             .executableTarget(
                     name: "imgcopy",
                     dependencies: ["ImgCopyMod"],
-                    resources: [.copy("version.txt")]
+                    resources: [.embedInCode("version.txt")]
             ),
             .executableTarget(
                 name: "imgview",
                 dependencies: [
                     .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 ],
-                resources: [.copy("version.txt")]
+                resources: [.embedInCode("version.txt")]
             ),
             .target(
                     name: "ImgCopyMod",

--- a/Sources/imgfile/ImgFileExtension.swift
+++ b/Sources/imgfile/ImgFileExtension.swift
@@ -14,8 +14,7 @@ extension ImgFile {
     static var version: String {
         get {
             guard
-                let versionTextURL = Bundle.module.url(forResource: "version", withExtension: "txt"),
-                let text = versionTextURL.text
+                let text = String(bytes: PackageResources.version_txt, encoding: .utf8)
             else {
                 return "unknown"
             }

--- a/Sources/imgview/imgview.swift
+++ b/Sources/imgview/imgview.swift
@@ -79,8 +79,7 @@ extension ImgView {
     static var version: String {
         get {
             guard
-                let versionTextURL = Bundle.module.url(forResource: "version", withExtension: "txt"),
-                let text = versionTextURL.text
+                let text = String(bytes: PackageResources.version_txt, encoding: .utf8)
             else {
                 return "unknown"
             }
@@ -117,7 +116,7 @@ extension URL {
     }
 }
 
-extension ImageSource {
+public extension ImageSource {
     init(_ source: String?) {
         #if DEBUG
             print("image source: source=\(String(describing: source))")
@@ -134,7 +133,7 @@ extension ImageSource {
     }
 }
 
-enum ImageSource {
+public enum ImageSource: Equatable {
     case file(path: String)
     case clipboard
 


### PR DESCRIPTION
Replace `.copy` with `.embedInCode` for resources and refactor version loading logic.

- Updated `Package.swift` to use `.embedInCode` instead of `.copy` for the `version.txt` resource in all targets.
- Refactored version loading logic in `imgview` and `imgfile` to use `PackageResources.version_txt` for improved performance and simplicity.
- Made `ImageSource` and `ImageSource: Equatable` `public` for better accessibility.